### PR TITLE
Added 'none' option to sorting to keep entries in same order.

### DIFF
--- a/bib/database.go
+++ b/bib/database.go
@@ -267,6 +267,9 @@ func (ps *pubSorter) Swap(i, j int) {
 // by Key. Uses the value.Less function to determine the order. If reverse is
 // true, this order will be reversed.
 func (db *Database) SortByField(field string, reverse bool) {
+	if field == "none" {
+		return
+	}
 	ps := &pubSorter{
 		pubs: db.Pubs,
 		by: func(e1, e2 *Entry) bool {
@@ -280,7 +283,7 @@ func (db *Database) SortByField(field string, reverse bool) {
 				ans = false
 			case !ok1 && !ok2:
 				ans = (e1.Key < e2.Key)
-			case ok1 && ok1:
+			case ok1 && ok2:
 				ans = db.Less(v1, v2)
 			}
 

--- a/biblint/biblint.go
+++ b/biblint/biblint.go
@@ -97,7 +97,7 @@ func parseBibFromArgs(c *subcommand) (*bib.Database, bool) {
 
 // doFmt reads a bibtex file and formats it using a "standard" format.
 func doClean(c *subcommand) bool {
-	sortby := c.flags.String("sort", "year", "sorts the entry by `field`")
+	sortby := c.flags.String("sort", "year", "sorts the entry by `field` or `none` to skip sort")
 	reverse := c.flags.Bool("reverse", true, "reverse the sort order")
 	blessed := c.flags.String("blessed", "", "Comma separated list of blessed `fields`")
 


### PR DESCRIPTION
By using `--sort none` in `biblint clean`, the order of the entries in the database is not changed, making using `diff` and `patch` (and `git`) with a clean database that much more pleasant.

I feel that `none` should actually be the default and that asking to sort by some field should be explicitly asked for. In part because the current sorting is "broken": it is highly unstable and consequently hard to use.