### PR TITLE
Warning on full-field braces

### DIFF
--- a/biblint/biblint.go
+++ b/biblint/biblint.go
@@ -177,6 +177,7 @@ func doCheck(c *subcommand) bool {
 	db.CheckRequiredFields()
 	db.CheckUnmatchedDollarSigns()
 	db.CheckRedundantSymbols()
+	db.CheckWholeFieldBraces()
 
 	db.NormalizeAuthors()
 	db.CheckAuthorLast()

--- a/biblint/tests/check_wholefieldbrace_exp.bib
+++ b/biblint/tests/check_wholefieldbrace_exp.bib
@@ -1,0 +1,19 @@
+Key "key11":
+  75:title: field "title" is entirely enclosed in extra braces
+
+Key "key2":
+  9:journal: field "journal" is entirely enclosed in extra braces
+
+Key "key3":
+  17:journal: field "journal" is entirely enclosed in extra braces
+  17:title: field "title" is entirely enclosed in extra braces
+
+Key "key4":
+  25:title: field "title" is entirely enclosed in extra braces
+
+Key "key5":
+  33:journal: field "journal" is entirely enclosed in extra braces
+
+Key "key8":
+  54:year: year is not an integer "{8}"
+

--- a/biblint/tests/check_wholefieldbrace_in.bib
+++ b/biblint/tests/check_wholefieldbrace_in.bib
@@ -1,0 +1,87 @@
+@article{key1,
+  author = {A. U. Thor and S. E. Cond},
+  title  = {A Study on Something Interesting},
+  journal    = {{arXiv}},
+  year       = 1,
+  volume     = 3,
+}
+
+@article{key2,
+  author = {B. I. Ologist and R. E. Searcher},
+  title  = {Another Study on Something Else},
+  journal    = {{New joUrNal of arXiv}},
+  year       = 2,
+    volume     = 3,
+}
+
+@article{key3,
+  author = {C. O. Author and D. E. Veloper},
+  title  = {{Further Studies on Interesting Topics}},
+  journal    = {{PLoS Computational Biology}},
+  year       = 3,
+    volume     = 3,
+}
+
+@article{key4,
+  author = {E. X. Pert and F. O. Rmer},
+  title  = {{Final Study on the {Most} Interesting Thing}},
+  journal    = {JCB},
+  year       = 4,
+    volume     = 3,
+}
+
+@article{key5,
+  author = {G. E. Nius and H. I. Story},
+  title  = {An Additional Study on Something Interesting},
+  journal    = "{journal of computational biology}",
+  year       = 5,
+    volume     = 3,
+}
+@article{key6,
+  author = {I. M. Pactor and J. K. Nowledge},
+  title  = {Yet Another Study on Something Interesting},
+  journal    = "{plos computational biology}  ",
+  year       = 6,
+    volume     = 3,
+}
+@article{key7,
+  author = {L. A. Bels and M. O. Del},
+  title  = {A Complementary Study on Something Interesting},
+  journal    = "jcb",
+  year       = 7,
+    volume     = 3,
+}
+@article{key8,
+  author = {N. E. Writter and O. P. Erator},
+  title  = {A Supplementary Study on Something Interesting},
+  journal    = "PLOS COMPUTATIONAL BIOLOGY",
+  year       = {{8}},
+    volume     = 3,
+}
+@article{key9,
+  author = {P. R. Ofessor and Q. U. Izz},
+  title  = {{An} Extended Study on Something {Interesting}},
+  journaltitle    = "NEW JOURNAL OF ARXIV",
+  year       = 9,
+    volume     = 3,
+}
+@article{key10,
+  author = {R. E. Searcher and S. E. Cond},
+  title  = {A Further Study on Something Interesting},
+  journal    = "ARXIV",
+  year       = 10,
+    volume     = 3,
+}
+@inprocedings{key11,
+  author = {T. H. Eorist and U. N. Dertaker},
+  title  = {{An Extra Study on Something Interesting}},
+  journal    = {"PLoS Computational Biology"},
+  year       = 11,
+}
+@article{key12,
+  author = {V. A. Lue and W. R. Iter},
+  title  = {A Subsequent Study on Something Interesting},
+  journal    = "J of Computational Biology",
+  year       = 12,
+    volume     = 3,
+}

--- a/notes/release-notes-v0.5.md
+++ b/notes/release-notes-v0.5.md
@@ -1,5 +1,5 @@
 # Release Notes Version 0.5
-Feb 5, 2026
+Feb 2, 2026
 
 - Bumped version to 0.5 and copyright stmt to 2026.
 - Fixed some modern code warnings / lints.
@@ -11,6 +11,8 @@ Feb 5, 2026
 - Added some tests in `tests.sh` for `check` command.
 - Don't change case of sTraNge-caSe journal title words.
 - Fixed title-casing bugs in journal names with nested {} regions.
+- `check` reports warning if a field is entirely enclosed in {} braces (unless
+  it's a single-word field) (#9)
 - Blessed field name `biblint__options`. This field name is reserved for future 
   biblint use. At present, it doesn't do anything, but in the future, it may be
   used to hold per-entry options. The only change in this release is that if

--- a/notes/release-notes-v0.5.md
+++ b/notes/release-notes-v0.5.md
@@ -13,6 +13,7 @@ Feb 2, 2026
 - Fixed title-casing bugs in journal names with nested {} regions.
 - `check` reports warning if a field is entirely enclosed in {} braces (unless
   it's a single-word field) (#9)
+- fixed "bug" where order of warning messages in `check` changed randomly
 - Blessed field name `biblint__options`. This field name is reserved for future 
   biblint use. At present, it doesn't do anything, but in the future, it may be
   used to hold per-entry options. The only change in this release is that if
@@ -22,4 +23,3 @@ Feb 2, 2026
   can mangle journal names. But it can also help normalize journal names.
   Use `--merge-journal-names=k` with `k` equal to the minimum number of entries 
   of similar journal names needed to symbolize a name.
-


### PR DESCRIPTION
- `check` reports warning if a field is entirely enclosed in {} braces (unless it's a single-word field) (#9)